### PR TITLE
Update feature

### DIFF
--- a/assets/RagePixel/code/RagePixelCell.cs
+++ b/assets/RagePixel/code/RagePixelCell.cs
@@ -9,6 +9,8 @@ public class RagePixelCell
 	public int key;
 	public Rect uv;
 	public int delay;
+	
+	public string importAssetPath;
 
 	public void ClearUndoHistory()
 	{


### PR DESCRIPTION
Took a bit to figure out but I finally got GitHub Mac setup. I'll merge as soon as this pull request is sent.

The path to the texture of the imported asset is saved in the
RagePixelCell. Options to update the selected frame, sprite, or all
sprites are implemented. Does not maintain a connection with imported
sprite sheets.

If textures are moved just replace the existing frame and the
connection will be setup again. The name of the file is listed beside
the frame index.

Bug Fix: Imported sprites were scaling to the nearest power of 2.
