### PR TITLE
Update assets/RagePixel/code/RagePixelRow.cs

### DIFF
--- a/assets/RagePixel/code/RagePixelRow.cs
+++ b/assets/RagePixel/code/RagePixelRow.cs
@@ -11,7 +11,7 @@ public class RagePixelRow
 	public int newPixelSizeX;
 	public int newPixelSizeY;
 	public int key;
-	public string name;
+	public string name = "";
 	[HideInInspector]
 	public string fontCharacter = "";
 	[HideInInspector]


### PR DESCRIPTION
I noticed when trying to give a name to sprites it kept bugging up, caused by a null reference. Did a little search and noticed the name was null, so this is to fix it. I can verify that it works because I use the modified code myself :P 
