### PR TITLE
Flood Fill

### DIFF
--- a/assets/RagePixel/editor/RagePixelTexel.cs
+++ b/assets/RagePixel/editor/RagePixelTexel.cs
@@ -16,5 +16,10 @@ public class RagePixelTexel
 		X = _x;
 		Y = _y;
 	}
+
+    public static RagePixelTexel operator +(RagePixelTexel a, RagePixelTexel b)
+    {
+        return new RagePixelTexel(a.X + b.X, a.Y + b.Y);
+    }
 }
 


### PR DESCRIPTION
Fixing stack overflow issue with FloodFill in large sprites 
Added a method to compare colors with a threshold (used by FloodFill)
    Sometimes the texture has "slightly" different color than we want in it
Adding a operator+ to RagePixelTexel (used by FloodFill)
